### PR TITLE
build: update to more modern CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,57 +1,18 @@
+#[[
+Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+All Rights Reserved.
 
-cmake_minimum_required(VERSION 3.13)
+SPDX-License-Identifier: BSD-3
+#]]
 
-project(uSwift LANGUAGES C)
+cmake_minimum_required(VERSION 3.18)
 
-add_library(swiftRuntime STATIC
-            ${CMAKE_SOURCE_DIR}/Source/Runtime/Metadata.c
-            ${CMAKE_SOURCE_DIR}/Source/Runtime/KnownMetadata.c)
+project(uSwift
+  LANGUAGES C Swift)
 
-set(SwiftCore_SOURCES
-    ${CMAKE_SOURCE_DIR}/Source/Core/Bool.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/CompilerProtocols.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/Equatable.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/Int.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/Int8.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/Int32.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/Integers.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/Never.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/Optional.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/OptionSet.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/Policy.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/Swift.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/UInt.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/UInt8.swift
-    ${CMAKE_SOURCE_DIR}/Source/Core/UInt32.swift)
-add_custom_command(OUTPUT
-                     ${CMAKE_CURRENT_BINARY_DIR}/Swift${CMAKE_C_OUTPUT_EXTENSION}
-                   COMMAND
-                     ${CMAKE_Swift_COMPILER} -frontend -target ${CMAKE_C_COMPILE_TARGET} -module-name Swift -parse-as-library -parse-stdlib -enable-resilience -c ${SwiftCore_SOURCES} -o ${CMAKE_CURRENT_BINARY_DIR}/Swift${CMAKE_C_OUTPUT_EXTENSION} -emit-module -emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/Swift.swiftmodule
-                   DEPENDS
-                     ${SwiftCore_SOURCES})
-add_custom_target(swiftCore_OBJECT
-                  DEPENDS
-                    ${CMAKE_CURRENT_BINARY_DIR}/Swift${CMAKE_C_OUTPUT_EXTENSION})
+set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+set(CMAKE_Swift_MODULE_DIRECTORY ${CMAKE_BINARY_DIR}/swift)
 
-add_library(swiftCore ${CMAKE_CURRENT_BINARY_DIR}/Swift${CMAKE_C_OUTPUT_EXTENSION})
-target_link_libraries(swiftCore PRIVATE swiftRuntime)
-set_target_properties(swiftCore PROPERTIES LINKER_LANGUAGE C)
-target_link_options(swiftCore PRIVATE -nostdlib -fuse-ld=gold -Wl,-u,swift_addNewDSOImage)
-
-set(SwiftOnoneSupport_SOURCES
-    ${CMAKE_SOURCE_DIR}/Source/Onone/SwiftOnoneSupport.swift)
-add_custom_command(OUTPUT
-                     ${CMAKE_CURRENT_BINARY_DIR}/SwiftOnoneSupport${CMAKE_C_OUTPUT_EXTENSION}
-                   COMMAND
-                     ${CMAKE_Swift_COMPILER} -frontend -target ${CMAKE_C_COMPILE_TARGET} -module-name SwiftOnoneSupport -parse-as-library -parse-stdlib -enable-resilience -c ${SwiftOnoneSupport_SOURCES} -o ${CMAKE_CURRENT_BINARY_DIR}/SwiftOnoneSupport${CMAKE_C_OUTPUT_EXTENSION} -emit-module -emit-module-path ${CMAKE_CURRENT_BINARY_DIR}/SwiftOnoneSupport.swiftmodule
-                   DEPENDS
-                     ${SwiftOnoneSupport_SOURCES})
-add_custom_target(swiftOnoneSupport_OBJECT
-                  DEPENDS
-                    ${CMAKE_CURRENT_BINARY_DIR}/SwiftOnoneSupport${CMAKE_C_OUTPUT_EXTENSION})
-
-add_library(swiftOnoneSupport ${CMAKE_CURRENT_BINARY_DIR}/SwiftOnoneSupport${CMAKE_C_OUTPUT_EXTENSION})
-target_link_libraries(swiftOnoneSupport PRIVATE swiftCore)
-set_target_properties(swiftOnoneSupport PROPERTIES LINKER_LANGUAGE C)
-target_link_options(swiftOnoneSupport PRIVATE -nostdlib -fuse-ld=gold)
-
+add_subdirectory(Source)

--- a/Source/CMakeLists.txt
+++ b/Source/CMakeLists.txt
@@ -1,0 +1,10 @@
+#[[
+Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+All Rights Reserved.
+
+SPDX-License-Identifier: BSD-3
+#]]
+
+add_subdirectory(Runtime)
+add_subdirectory(Core)
+add_subdirectory(Onone)

--- a/Source/Core/CMakeLists.txt
+++ b/Source/Core/CMakeLists.txt
@@ -1,0 +1,32 @@
+#[[
+Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+All Rights Reserved.
+
+SPDX-License-Identifier: BSD-3
+#]]
+
+add_library(swiftCore
+  Bool.swift
+  CompilerProtocols.swift
+  Equatable.swift
+  Int.swift
+  Int8.swift
+  Int32.swift
+  Integers.swift
+  Never.swift
+  Optional.swift
+  OptionSet.swift
+  Policy.swift
+  Swift.swift
+  UInt.swift
+  UInt8.swift
+  UInt32.swift)
+set_target_properties(swiftCore PROPERTIES
+  Swift_MODULE_NAME Swift)
+target_compile_options(swiftCore PRIVATE
+  -parse-stdlib
+  "SHELL:-Xfrontend -enable-resilience")
+target_link_libraries(swiftCore PRIVATE
+  swiftRuntime)
+target_link_options(swiftCore PRIVATE
+  "SHELL:-Xclang-linker -nostdlib")

--- a/Source/Onone/CMakeLists.txt
+++ b/Source/Onone/CMakeLists.txt
@@ -1,0 +1,18 @@
+#[[
+Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+All Rights Reserved.
+
+SPDX-License-Identifier: BSD-3
+#]]
+
+add_library(swiftOnoneSupport
+  SwiftOnoneSupport.swift)
+set_target_properties(swiftOnoneSupport PROPERTIES
+  Swift_MODULE_NAME SwiftOnoneSupport)
+target_compile_options(swiftOnoneSupport PRIVATE
+  -parse-stdlib
+  "SHELL:-Xfrontend -enable-resilience")
+target_link_libraries(swiftOnoneSupport PUBLIC
+  swiftCore)
+target_link_options(swiftOnoneSupport PRIVATE
+  "SHELL:-Xclang-linker -nostdlib")

--- a/Source/Runtime/CMakeLists.txt
+++ b/Source/Runtime/CMakeLists.txt
@@ -1,0 +1,10 @@
+#[[
+Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+All Rights Reserved.
+
+SPDX-License-Identifier: BSD-3
+#]]
+
+add_library(swiftRuntime STATIC
+  Metadata.c
+  KnownMetadata.c)


### PR DESCRIPTION
This updates the build to use CMake 3.18.  The result of that is that we
can use the modern Swift support in CMake to build the library.  It
greatly simplifies the handling.  While cleaning up the build rules,
attempt to support Windows and Darwin a bit better.