### PR TITLE
Runtime: add additional stubs for building uSwift

### DIFF
--- a/Source/Runtime/CMakeLists.txt
+++ b/Source/Runtime/CMakeLists.txt
@@ -6,5 +6,7 @@ SPDX-License-Identifier: BSD-3
 #]]
 
 add_library(swiftRuntime STATIC
+  Enum.c
+  HeapObject.c
   Metadata.c
   KnownMetadata.c)

--- a/Source/Runtime/Enum.c
+++ b/Source/Runtime/Enum.c
@@ -1,0 +1,23 @@
+
+#include "Types.h"
+#include "Visibility.h"
+
+SWIFT_RUNTIME_ABI
+void swift_initEnumMetadataSinglePayload(EnumMetadata *self,
+                                         EnumLayoutFlags flags,
+                                         const TypeLayout *layout,
+                                         unsigned empty_cases) {}
+
+SWIFT_RUNTIME_ABI
+unsigned swift_getEnumTagSinglePayloadGeneric(const OpaqueValue *value,
+                                              unsigned empty_cases,
+                                              const Metadata *type) {
+  return 0;
+}
+
+SWIFT_RUNTIME_ABI
+void swift_storeEnumTagSinglePayloadGeneric(OpaqueValue *value,
+                                            unsigned store_case,
+                                            unsigned empty_cases,
+                                            const Metadata *payload,
+                                            StoreExtraInhabitantTagFn *store) {}

--- a/Source/Runtime/HeapObject.c
+++ b/Source/Runtime/HeapObject.c
@@ -1,0 +1,8 @@
+
+#include <stdlib.h>
+
+#include "Types.h"
+#include "Visibility.h"
+
+SWIFT_RUNTIME_ABI
+HeapObject *swift_retain(HeapObject *object) { return NULL; }

--- a/Source/Runtime/KnownMetadata.c
+++ b/Source/Runtime/KnownMetadata.c
@@ -9,11 +9,9 @@
 #define SWIFT_RUNTIME_ABI __declspec(dllexport)
 #endif
 
-struct ValueWitnessTable {
-};
+struct ValueWitnessTable {};
 
-struct TypeMetadata {
-};
+struct TypeMetadata {};
 
 SWIFT_RUNTIME_ABI
 struct ValueWitnessTable $sBi8_WV;
@@ -32,4 +30,3 @@ struct TypeMetadata $sBi8_N;
 
 SWIFT_RUNTIME_ABI
 struct TypeMetadata $sBi32_N;
-

--- a/Source/Runtime/Metadata.c
+++ b/Source/Runtime/Metadata.c
@@ -1,15 +1,27 @@
 
-#if defined(__ELF__)
-#define SWIFT_RUNTIME_ABI __attribute__((__visibility__("default")))
-#elif defined(__MACH__)
-#define SWIFT_RUNTIME_ABI __attribute__((__visibility__("default")))
-#elif defined(__WASM__)
-#define SWIFT_RUNTIME_ABI __attribute__((__visibility__("default")))
-#else
-#define SWIFT_RUNTIME_ABI __declspec(dllexport)
-#endif
+#include "Types.h"
+#include "Visibility.h"
+#include <stdlib.h>
 
 SWIFT_RUNTIME_ABI
-void swift_addNewDSOImage() {
+void swift_addNewDSOImage() {}
+
+SWIFT_RUNTIME_ABI
+ValueMetadata *swift_allocateGenericValueMetadata(
+    const ValueTypeDescriptor *descriptor, const void *arguments,
+    const GenericValueMetadataPattern *pattern, size_t extra) {
+  return NULL;
 }
 
+SWIFT_RUNTIME_ABI
+MetadataResponse swift_checkMetadataState(MetadataRequest request,
+                                          const Metadata *metdata) {
+  return (MetadataResponse){};
+};
+
+SWIFT_RUNTIME_ABI
+MetadataResponse
+swift_getGenericMetadata(MetadataRequest request, const void *const *arguments,
+                         const TypeContextDescriptor *descriptor) {
+  return (MetadataResponse){};
+}

--- a/Source/Runtime/Types.h
+++ b/Source/Runtime/Types.h
@@ -1,0 +1,32 @@
+
+#ifndef uSwift_Runtime_Types_h
+#define uSwift_Runtime_Types_h
+
+typedef struct Metadata Metadata;
+typedef struct EnumMetadata EnumMetadata;
+typedef struct ValueMetadata ValueMetadata;
+typedef struct OpaqueValue OpaqueValue;
+
+typedef struct ValueTypeDescriptor ValueTypeDescriptor;
+typedef struct GenericValueMetadataPattern GenericValueMetadataPattern;
+
+typedef struct MetdataRequest {
+} MetadataRequest;
+typedef struct MetdataResponse {
+} MetadataResponse;
+
+typedef struct TypeContextDescriptor TypeContextDescriptor;
+typedef struct TypeLayout TypeLayout;
+
+typedef struct HeapObject HeapObject;
+
+typedef enum EnumLayoutFlags {
+  invalid,
+} EnumLayoutFlags;
+
+typedef void(__attribute__((__swiftcall__)) *
+             StoreExtraInhabitantTagFn)(OpaqueValue *value, unsigned store_case,
+                                        unsigned extra_inhabitants,
+                                        const Metadata *payload);
+
+#endif

--- a/Source/Runtime/Visibility.h
+++ b/Source/Runtime/Visibility.h
@@ -1,0 +1,15 @@
+
+#ifndef uSwift_Runtime_Visibility_h
+#define uSwift_Runtime_Visibility_h
+
+#if defined(__ELF__)
+#define SWIFT_RUNTIME_ABI __attribute__((__visibility__("default")))
+#elif defined(__MACH__)
+#define SWIFT_RUNTIME_ABI __attribute__((__visibility__("default")))
+#elif defined(__WASM__)
+#define SWIFT_RUNTIME_ABI __attribute__((__visibility__("default")))
+#else
+#define SWIFT_RUNTIME_ABI __declspec(dllexport)
+#endif
+
+#endif


### PR DESCRIPTION
Ensure that we have placeholders for the referenced functions.  This
allows us to build a version of uSwift, even if it is unable to handle
these callouts.