### PR TITLE
Core: replace `@_fixed_layout` with `@frozen`

### DIFF
--- a/Source/Core/Bool.swift
+++ b/Source/Core/Bool.swift
@@ -1,5 +1,5 @@
 
-@_fixed_layout
+@frozen
 public struct Bool {
   @usableFromInline
   internal var _value: Builtin.Int1

--- a/Source/Core/Int.swift
+++ b/Source/Core/Int.swift
@@ -2,7 +2,7 @@
 // XXX(compnerd) why can `Int` not be a typealias?
 // The typealias does not inherit the Equatable conformance
 
-@_fixed_layout
+@frozen
 public struct Int {
   @usableFromInline
   internal var _value: Builtin.Int32

--- a/Source/Core/Int32.swift
+++ b/Source/Core/Int32.swift
@@ -1,5 +1,5 @@
 
-@_fixed_layout
+@frozen
 public struct Int32 {
   @usableFromInline
   internal var _value: Builtin.Int32

--- a/Source/Core/Int8.swift
+++ b/Source/Core/Int8.swift
@@ -1,5 +1,5 @@
 
-@_fixed_layout
+@frozen
 public struct Int8 {
   @usableFromInline
   internal var _value: Builtin.Int8

--- a/Source/Core/UInt.swift
+++ b/Source/Core/UInt.swift
@@ -2,7 +2,7 @@
 // XXX(compnerd) why can `UInt` not be a typealias?
 // The typealias does not inherit the Equatable conformance
 
-@_fixed_layout
+@frozen
 public struct UInt {
   @usableFromInline
   internal var _value: Builtin.Int32

--- a/Source/Core/UInt32.swift
+++ b/Source/Core/UInt32.swift
@@ -1,5 +1,5 @@
 
-@_fixed_layout
+@frozen
 public struct UInt32 {
   @usableFromInline
   internal var _value: Builtin.Int32

--- a/Source/Core/UInt8.swift
+++ b/Source/Core/UInt8.swift
@@ -1,5 +1,5 @@
 
-@_fixed_layout
+@frozen
 public struct UInt8 {
   @usableFromInline
   internal var _value: Builtin.Int8


### PR DESCRIPTION
The `@_fixed_layout` attribute has been replaced by `@frozen`.  Update
the sources to avoid the warning.