### PR TITLE
add copyright headers

### DIFF
--- a/Source/Core/Bool.swift
+++ b/Source/Core/Bool.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 @frozen
 public struct Bool {

--- a/Source/Core/CompilerProtocols.swift
+++ b/Source/Core/CompilerProtocols.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 public protocol _ExpressibleByBuiltinBooleanLiteral {
   init(_builtinBooleanLiteral value: Builtin.Int1)

--- a/Source/Core/Equatable.swift
+++ b/Source/Core/Equatable.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 public protocol Equatable {
   static func == (lhs: Self, rhs: Self) -> Bool

--- a/Source/Core/Int.swift
+++ b/Source/Core/Int.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 // XXX(compnerd) why can `Int` not be a typealias?
 // The typealias does not inherit the Equatable conformance

--- a/Source/Core/Int32.swift
+++ b/Source/Core/Int32.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 @frozen
 public struct Int32 {

--- a/Source/Core/Int8.swift
+++ b/Source/Core/Int8.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 @frozen
 public struct Int8 {

--- a/Source/Core/Integers.swift
+++ b/Source/Core/Integers.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 extension ExpressibleByIntegerLiteral
     where Self : _ExpressibleByBuiltinIntegerLiteral {

--- a/Source/Core/Never.swift
+++ b/Source/Core/Never.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 @_frozen
 public enum Never {}

--- a/Source/Core/OptionSet.swift
+++ b/Source/Core/OptionSet.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 public protocol OptionSet : RawRepresentable {
   associatedtype Element = Self

--- a/Source/Core/Optional.swift
+++ b/Source/Core/Optional.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 @_frozen
 public enum Optional<Wrapped> : ExpressibleByNilLiteral {

--- a/Source/Core/Policy.swift
+++ b/Source/Core/Policy.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 public typealias BooleanLiteralType = Bool
 

--- a/Source/Core/UInt.swift
+++ b/Source/Core/UInt.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 // XXX(compnerd) why can `UInt` not be a typealias?
 // The typealias does not inherit the Equatable conformance

--- a/Source/Core/UInt32.swift
+++ b/Source/Core/UInt32.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 @frozen
 public struct UInt32 {

--- a/Source/Core/UInt8.swift
+++ b/Source/Core/UInt8.swift
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 @frozen
 public struct UInt8 {

--- a/Source/Core/Void.swift
+++ b/Source/Core/Void.swift
@@ -1,2 +1,5 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 public typealias Void = ()

--- a/Source/Runtime/Enum.c
+++ b/Source/Runtime/Enum.c
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 #include "Types.h"
 #include "Visibility.h"

--- a/Source/Runtime/HeapObject.c
+++ b/Source/Runtime/HeapObject.c
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 #include <stdlib.h>
 

--- a/Source/Runtime/KnownMetadata.c
+++ b/Source/Runtime/KnownMetadata.c
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 #if defined(__ELF__)
 #define SWIFT_RUNTIME_ABI __attribute__((__visibility__("default")))

--- a/Source/Runtime/Types.h
+++ b/Source/Runtime/Types.h
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 #ifndef uSwift_Runtime_Types_h
 #define uSwift_Runtime_Types_h

--- a/Source/Runtime/Visibility.h
+++ b/Source/Runtime/Visibility.h
@@ -1,3 +1,6 @@
+// Copyright © 2018 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
 
 #ifndef uSwift_Runtime_Visibility_h
 #define uSwift_Runtime_Visibility_h


### PR DESCRIPTION
Add missing copyright headers to the Core and Runtime libraries.