### PR TITLE
Core: use `@frozen` over `@_frozen`

### DIFF
--- a/Sources/Core/Never.swift
+++ b/Sources/Core/Never.swift
@@ -2,5 +2,5 @@
 // All Rights Reserved.
 // SPDX-License-Identifier: BSD-3
 
-@_frozen
+@frozen
 public enum Never {}

--- a/Sources/Core/Optional.swift
+++ b/Sources/Core/Optional.swift
@@ -2,7 +2,7 @@
 // All Rights Reserved.
 // SPDX-License-Identifier: BSD-3
 
-@_frozen
+@frozen
 public enum Optional<Wrapped>: ExpressibleByNilLiteral {
   case none
   case some(Wrapped)


### PR DESCRIPTION
The original `@_fixed_layout` attribute was replaced with `@_frozen`
which was then replaced with the accepted `@frozen` spelling.  Replace
the two instances of `@_frozen` with `@frozen` to be uniform in usage
throughout the implementation.