### PR TITLE
Lower required cmake version to 3.16.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ All Rights Reserved.
 SPDX-License-Identifier: BSD-3
 #]]
 
-cmake_minimum_required(VERSION 3.18)
+cmake_minimum_required(VERSION 3.16)
 
 project(uSwift
   LANGUAGES C Swift)


### PR DESCRIPTION
Some of the Linux Swift project build bots only have version 3.16 installed. It's unclear if 3.18 is a requirement for Linux too (the docs just say macOS), but either way, they should probably be updated. That being said, this is easier than updating all the build bots (or, more realistically, asking Mishal to).