### PR TITLE
Runtime: share the visibility types

### DIFF
--- a/Sources/Runtime/KnownMetadata.c
+++ b/Sources/Runtime/KnownMetadata.c
@@ -2,34 +2,23 @@
 // All Rights Reserved.
 // SPDX-License-Identifier: BSD-3
 
-#if defined(__ELF__)
-#define SWIFT_RUNTIME_ABI __attribute__((__visibility__("default")))
-#elif defined(__MACH__)
-#define SWIFT_RUNTIME_ABI __attribute__((__visibility__("default")))
-#elif defined(__WASM__)
-#define SWIFT_RUNTIME_ABI __attribute__((__visibility__("default")))
-#else
-#define SWIFT_RUNTIME_ABI __declspec(dllexport)
-#endif
-
-struct ValueWitnessTable {};
-
-struct TypeMetadata {};
+#include "Types.h"
+#include "Visibility.h"
 
 SWIFT_RUNTIME_ABI
-struct ValueWitnessTable $sBi8_WV;
+ValueWitnessTable $sBi8_WV;
 
 SWIFT_RUNTIME_ABI
-struct ValueWitnessTable $sBi32_WV;
+ValueWitnessTable $sBi32_WV;
 
 SWIFT_RUNTIME_ABI
-struct ValueWitnessTable $sytWV;
+ValueWitnessTable $sytWV;
 
 SWIFT_RUNTIME_ABI
-struct TypeMetadata $sBi1_N;
+TypeMetadata $sBi1_N;
 
 SWIFT_RUNTIME_ABI
-struct TypeMetadata $sBi8_N;
+TypeMetadata $sBi8_N;
 
 SWIFT_RUNTIME_ABI
-struct TypeMetadata $sBi32_N;
+TypeMetadata $sBi32_N;

--- a/Sources/Runtime/Types.h
+++ b/Sources/Runtime/Types.h
@@ -6,12 +6,16 @@
 #define uSwift_Runtime_Types_h
 
 typedef struct Metadata Metadata;
-typedef struct EnumMetadata EnumMetadata;
-typedef struct ValueMetadata ValueMetadata;
 typedef struct OpaqueValue OpaqueValue;
 
-typedef struct ValueTypeDescriptor ValueTypeDescriptor;
+typedef enum EnumLayoutFlags {
+  invalid,
+} EnumLayoutFlags;
+typedef struct EnumMetadata EnumMetadata;
+
 typedef struct GenericValueMetadataPattern GenericValueMetadataPattern;
+
+typedef struct HeapObject HeapObject;
 
 typedef struct MetdataRequest {
 } MetadataRequest;
@@ -20,12 +24,13 @@ typedef struct MetdataResponse {
 
 typedef struct TypeContextDescriptor TypeContextDescriptor;
 typedef struct TypeLayout TypeLayout;
+typedef struct TypeMetadata {
+} TypeMetadata;
 
-typedef struct HeapObject HeapObject;
-
-typedef enum EnumLayoutFlags {
-  invalid,
-} EnumLayoutFlags;
+typedef struct ValueMetadata ValueMetadata;
+typedef struct ValueTypeDescriptor ValueTypeDescriptor;
+typedef struct ValueWitnessTable {
+} ValueWitnessTable;
 
 typedef void(__attribute__((__swiftcall__)) *
              StoreExtraInhabitantTagFn)(OpaqueValue *value, unsigned store_case,


### PR DESCRIPTION
Use the common definitions rather than redefining macros everywhere.
Centralise the type declarations in `Types.h`.