### PR TITLE
CI: build shared libraries

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
         run: |
           # workaround CMake 3.20.0 bug
           $SDK_ROOT = cygpath -m $env:SDKROOT
-          cmake -B out -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang-cl -D CMAKE_CXX_COMPILER=clang-cl -D CMAKE_MT=mt -D CMAKE_Swift_FLAGS="-sdk $SDK_ROOT" -G Ninja -S ${{ github.workspace }}
+          cmake -B out -D BUILD_SHARED_LIBS=YES -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang-cl -D CMAKE_CXX_COMPILER=clang-cl -D CMAKE_MT=mt -D CMAKE_Swift_FLAGS="-sdk $SDK_ROOT" -G Ninja -S ${{ github.workspace }}
 
       - name: build
         run: cmake --build out --config Release


### PR DESCRIPTION
Build shared libraries instead of static libraries.  This has two purposes:
1. Windows does not support static linking for Swift yet
2. This allows for ensuring that no undefined references remain

This already has helped catch a missing stub in the runtime, and will likely identify more missing entry points in the future.