### PR TITLE
Policy: correct the FP width

### DIFF
--- a/Sources/Core/Policy.swift
+++ b/Sources/Core/Policy.swift
@@ -6,7 +6,7 @@ public typealias BooleanLiteralType = Bool
 
 #if arch(arm64) || arch(powerpc64)
   public typealias _MaxBuiltinFloatType = Builtin.FPIEEE128
-#elseif arch(i386) || arch(x86_64)
+#elseif !(os(Windows) || os(Android)) && (arch(i386) || arch(x86_64))
   public typealias _MaxBuiltinFloatType = Builtin.FPIEEE80
 #else
   public typealias _MaxBuiltinFloatType = Builtin.FPIEEE64


### PR DESCRIPTION
Windows and Android do not support FP80 intentionally even on x86 architectures.  This allows for the 32-bit platform to match across architectures (FP32).