### PR TITLE
runtime: replace `stdlib.h` with `stddef.h`

### DIFF
--- a/Sources/Runtime/HeapObject.c
+++ b/Sources/Runtime/HeapObject.c
@@ -2,7 +2,7 @@
 // All Rights Reserved.
 // SPDX-License-Identifier: BSD-3
 
-#include <stdlib.h>
+#include <stddef.h>
 
 #include "Types.h"
 #include "Visibility.h"

--- a/Sources/Runtime/Metadata.c
+++ b/Sources/Runtime/Metadata.c
@@ -1,7 +1,7 @@
 
 #include "Types.h"
 #include "Visibility.h"
-#include <stdlib.h>
+#include <stddef.h>
 
 SWIFT_RUNTIME_ABI
 void swift_addNewDSOImage() {}


### PR DESCRIPTION
`stdlib.h` requires a presence of libc, which is not always available when targeting bare metal. Looks like `stddef.h` works just as well and doesn't need libc.