### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,14 +31,17 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      # - uses: seanmiddleditch/gha-setup-ninja@master
-      - uses: seanmiddleditch/gha-setup-vsdevenv@master
-
       - name: configure
         run: |
-          # workaround CMake 3.20.0 bug
-          $SDK_ROOT = cygpath -m $env:SDKROOT
-          cmake -B out -D BUILD_SHARED_LIBS=YES -D CMAKE_BUILD_TYPE=Release -D CMAKE_C_COMPILER=clang-cl -D CMAKE_CXX_COMPILER=clang-cl -D CMAKE_MT=mt -D CMAKE_Swift_FLAGS="-sdk $SDK_ROOT" -G Ninja -S ${{ github.workspace }}
+          cmake -B out `
+                -D BUILD_SHARED_LIBS=YES `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_C_COMPILER=clang-cl `
+                -D CMAKE_CXX_COMPILER=clang-cl `
+                -D CMAKE_MT=mt `
+                -D CMAKE_Swift_FLAGS="-sdk $env:SDKROOT" `
+                -G Ninja `
+                -S ${{ github.workspace }}
 
       - name: build
         run: cmake --build out --config Release


### PR DESCRIPTION
Remove workaround for older version of CMake.  It is no longer required, and more importantly actively disrupts the current builders.