### PR TITLE
Add `_Pointer` protocol with `init?(bitPattern:)`

### DIFF
--- a/Sources/Core/CMakeLists.txt
+++ b/Sources/Core/CMakeLists.txt
@@ -18,6 +18,7 @@ add_library(swiftCore
   OpaquePointer.swift
   Optional.swift
   OptionSet.swift
+  Pointer.swift
   Policy.swift
   Swift.swift
   UInt.swift

--- a/Sources/Core/Pointer.swift
+++ b/Sources/Core/Pointer.swift
@@ -1,0 +1,61 @@
+// Copyright © 2022 Max Desiatov <max@desiatov.com>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
+
+public protocol _Pointer {
+  typealias Distance = Int
+
+  associatedtype Pointee
+
+  var _rawValue: Builtin.RawPointer { get }
+
+  init(_ _rawValue: Builtin.RawPointer)
+}
+
+extension _Pointer {
+
+#if swift(>=5.6)
+
+  @_transparent
+  public init(_ from: OpaquePointer) {
+    self.init(from._rawValue)
+  }
+
+  @_transparent
+  public init?(_ from: OpaquePointer?) {
+    guard let unwrapped = from else { return nil }
+    self.init(unwrapped)
+  }
+
+#endif
+
+  @_transparent
+  public init?(bitPattern: Int) {
+    if bitPattern == 0 { return nil }
+    self.init(Builtin.inttoptr_Word(bitPattern._value))
+  }
+
+  @_transparent
+  public init?(bitPattern: UInt) {
+    if bitPattern == 0 { return nil }
+    self.init(Builtin.inttoptr_Word(bitPattern._value))
+  }
+
+  @_transparent
+  public init(@_nonEphemeral _ other: Self) {
+    self.init(other._rawValue)
+  }
+
+  @_transparent
+  public init?(@_nonEphemeral _ other: Self?) {
+    guard let unwrapped = other else { return nil }
+    self.init(unwrapped._rawValue)
+  }
+}
+
+extension _Pointer {
+  @_transparent
+  public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_eq_RawPointer(lhs._rawValue, rhs._rawValue))
+  }
+}

--- a/Sources/Core/UnsafeMutablePointer.swift
+++ b/Sources/Core/UnsafeMutablePointer.swift
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-3
 
 @frozen
-public struct UnsafeMutablePointer<Pointee> {
+public struct UnsafeMutablePointer<Pointee>: _Pointer {
   public let _rawValue: Builtin.RawPointer
 
   @_transparent

--- a/Sources/Core/UnsafePointer.swift
+++ b/Sources/Core/UnsafePointer.swift
@@ -3,7 +3,7 @@
 // SPDX-License-Identifier: BSD-3
 
 @frozen
-public struct UnsafePointer<Pointee> {
+public struct UnsafePointer<Pointee>: _Pointer {
   public let _rawValue: Builtin.RawPointer
 
   @_transparent


### PR DESCRIPTION
This initializer is needed to fully implement `StaticString`.

Depends on #34.