### PR TITLE
Add comments in `KnownMetadata.c`

### DIFF
--- a/Sources/Runtime/KnownMetadata.c
+++ b/Sources/Runtime/KnownMetadata.c
@@ -5,20 +5,26 @@
 #include "Types.h"
 #include "Visibility.h"
 
+// value witness table for Builtin.Int8
 SWIFT_RUNTIME_ABI
 ValueWitnessTable $sBi8_WV;
 
+// value witness table for Builtin.Int32
 SWIFT_RUNTIME_ABI
 ValueWitnessTable $sBi32_WV;
 
+// value witness table for ()
 SWIFT_RUNTIME_ABI
 ValueWitnessTable $sytWV;
 
+// type metadata for Builtin.Int1
 SWIFT_RUNTIME_ABI
 TypeMetadata $sBi1_N;
 
+// type metadata for Builtin.Int8
 SWIFT_RUNTIME_ABI
 TypeMetadata $sBi8_N;
 
+// type metadata for Builtin.Int32
 SWIFT_RUNTIME_ABI
 TypeMetadata $sBi32_N;


### PR DESCRIPTION
Text in these comments was produced with `swift demangle`, so now it's easier to understand what types are referenced in `KnownMetadata.c`.