### PR TITLE
Core: use word storage in `Int` and `UInt`

### DIFF
--- a/Sources/Core/Int.swift
+++ b/Sources/Core/Int.swift
@@ -2,19 +2,16 @@
 // All Rights Reserved.
 // SPDX-License-Identifier: BSD-3
 
-// XXX(compnerd) why can `Int` not be a typealias?
-// The typealias does not inherit the Equatable conformance
-
 @frozen
 public struct Int {
   @usableFromInline
-  internal var _value: Builtin.Int32
+  internal var _value: Builtin.Word
 }
 
 extension Int: _ExpressibleByBuiltinIntegerLiteral {
   @_transparent
   public init(_builtinIntegerLiteral value: Builtin.IntLiteral) {
-    _value = Builtin.s_to_s_checked_trunc_IntLiteral_Int32(value).0
+    _value = Builtin.s_to_s_checked_trunc_IntLiteral_Word(value).0
   }
 }
 
@@ -24,6 +21,6 @@ extension Int: ExpressibleByIntegerLiteral {
 extension Int: Equatable {
   @_transparent
   public static func == (lhs: Int, rhs: Int) -> Bool {
-    return Bool(Builtin.cmp_eq_Int32(lhs._value, rhs._value))
+    return Bool(Builtin.cmp_eq_Word(lhs._value, rhs._value))
   }
 }

--- a/Sources/Core/UInt.swift
+++ b/Sources/Core/UInt.swift
@@ -2,19 +2,16 @@
 // All Rights Reserved.
 // SPDX-License-Identifier: BSD-3
 
-// XXX(compnerd) why can `UInt` not be a typealias?
-// The typealias does not inherit the Equatable conformance
-
 @frozen
 public struct UInt {
   @usableFromInline
-  internal var _value: Builtin.Int32
+  internal var _value: Builtin.Word
 }
 
 extension UInt: _ExpressibleByBuiltinIntegerLiteral {
   @_transparent
   public init(_builtinIntegerLiteral value: Builtin.IntLiteral) {
-    _value = Builtin.s_to_u_checked_trunc_IntLiteral_Int32(value).0
+    _value = Builtin.s_to_u_checked_trunc_IntLiteral_Word(value).0
   }
 }
 
@@ -24,6 +21,6 @@ extension UInt: ExpressibleByIntegerLiteral {
 extension UInt: Equatable {
   @_transparent
   public static func == (lhs: UInt, rhs: UInt) -> Bool {
-    return Bool(Builtin.cmp_eq_Int32(lhs._value, rhs._value))
+    return Bool(Builtin.cmp_eq_Word(lhs._value, rhs._value))
   }
 }


### PR DESCRIPTION
This conforms `Int` and `UInt` to the specification of teh types as per
Swift: that they are pointer word sized.  This also more clearly
indicates why the typealias approach is less preferable.