### PR TITLE
Core: more style changes for integer types

### DIFF
--- a/Sources/Core/Int.swift
+++ b/Sources/Core/Int.swift
@@ -13,13 +13,13 @@ public struct Int {
   }
 
   @_transparent
-  public static func &= (_ lhs: inout Int, _ rhs: Int) {
+  public static func &= (_ lhs: inout Self, _ rhs: Self) {
     lhs = lhs & rhs
   }
 
   @_transparent
-  public static func & (_ lhs: Int, _ rhs: Int) -> Int {
-    Int(Builtin.and_Word(lhs._value, rhs._value))
+  public static func & (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(Builtin.and_Word(lhs._value, rhs._value))
   }
 }
 
@@ -35,7 +35,7 @@ extension Int: ExpressibleByIntegerLiteral {
 
 extension Int: Equatable {
   @_transparent
-  public static func == (_ lhs: Int, _ rhs: Int) -> Bool {
+  public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
     return Bool(Builtin.cmp_eq_Word(lhs._value, rhs._value))
   }
 }

--- a/Sources/Core/Int32.swift
+++ b/Sources/Core/Int32.swift
@@ -13,13 +13,13 @@ public struct Int32 {
   }
 
   @_transparent
-  public static func &= (_ lhs: inout Int32, _ rhs: Int32) {
+  public static func &= (_ lhs: inout Self, _ rhs: Self) {
     lhs = lhs & rhs
   }
 
   @_transparent
-  public static func & (_ lhs: Int32, _ rhs: Int32) -> Int32 {
-    return Int32(Builtin.and_Int32(lhs._value, rhs._value))
+  public static func & (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(Builtin.and_Int32(lhs._value, rhs._value))
   }
 }
 
@@ -35,7 +35,7 @@ extension Int32: ExpressibleByIntegerLiteral {
 
 extension Int32: Equatable {
   @_transparent
-  public static func == (lhs: Int32, rhs: Int32) -> Bool {
+  public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
     return Bool(Builtin.cmp_eq_Int32(lhs._value, rhs._value))
   }
 }

--- a/Sources/Core/Int8.swift
+++ b/Sources/Core/Int8.swift
@@ -13,13 +13,13 @@ public struct Int8 {
   }
 
   @_transparent
-  public static func &= (_ lhs: inout Int8, _ rhs: Int8) {
+  public static func &= (_ lhs: inout Self, _ rhs: Self) {
     lhs = lhs & rhs
   }
 
   @_transparent
-  public static func & (_ lhs: Int8, _ rhs: Int8) -> Int8 {
-    return Int8(Builtin.and_Int8(lhs._value, rhs._value))
+  public static func & (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(Builtin.and_Int8(lhs._value, rhs._value))
   }
 }
 
@@ -35,7 +35,7 @@ extension Int8: ExpressibleByIntegerLiteral {
 
 extension Int8: Equatable {
   @_transparent
-  public static func == (_ lhs: Int8, _ rhs: Int8) -> Bool {
+  public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
     return Bool(Builtin.cmp_eq_Int8(lhs._value, rhs._value))
   }
 }

--- a/Sources/Core/UInt.swift
+++ b/Sources/Core/UInt.swift
@@ -13,13 +13,13 @@ public struct UInt {
   }
 
   @_transparent
-  public static func &= (lhs: inout UInt, rhs: UInt) {
+  public static func &= (lhs: inout Self, rhs: Self) {
     lhs = lhs & rhs
   }
 
   @_transparent
-  public static func & (lhs: UInt, rhs: UInt) -> UInt {
-    return UInt(Builtin.and_Word(lhs._value, rhs._value))
+  public static func & (lhs: Self, rhs: Self) -> Self {
+    return Self(Builtin.and_Word(lhs._value, rhs._value))
   }
 }
 
@@ -35,7 +35,7 @@ extension UInt: ExpressibleByIntegerLiteral {
 
 extension UInt: Equatable {
   @_transparent
-  public static func == (lhs: UInt, rhs: UInt) -> Bool {
+  public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
     return Bool(Builtin.cmp_eq_Word(lhs._value, rhs._value))
   }
 }

--- a/Sources/Core/UInt32.swift
+++ b/Sources/Core/UInt32.swift
@@ -13,13 +13,13 @@ public struct UInt32 {
   }
 
   @_transparent
-  public static func &= (_ lhs: inout UInt32, _ rhs: UInt32) {
+  public static func &= (_ lhs: inout Self, _ rhs: Self) {
     lhs = lhs & rhs
   }
 
   @_transparent
-  public static func & (lhs: UInt32, rhs: UInt32) -> UInt32 {
-    return UInt32(Builtin.and_Int32(lhs._value, rhs._value))
+  public static func & (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(Builtin.and_Int32(lhs._value, rhs._value))
   }
 }
 
@@ -35,7 +35,7 @@ extension UInt32: ExpressibleByIntegerLiteral {
 
 extension UInt32: Equatable {
   @_transparent
-  public static func == (_ lhs: UInt32, _ rhs: UInt32) -> Bool {
+  public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
     return Bool(Builtin.cmp_eq_Int32(lhs._value, rhs._value))
   }
 }

--- a/Sources/Core/UInt8.swift
+++ b/Sources/Core/UInt8.swift
@@ -13,13 +13,13 @@ public struct UInt8 {
   }
 
   @_transparent
-  public static func &= (_ lhs: inout UInt8, _ rhs: UInt8) {
+  public static func &= (_ lhs: inout Self, _ rhs: Self) {
     lhs = lhs & rhs
   }
 
   @_transparent
-  public static func & (_ lhs: UInt8, _ rhs: UInt8) -> UInt8 {
-    return UInt8(Builtin.and_Int8(lhs._value, rhs._value))
+  public static func & (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(Builtin.and_Int8(lhs._value, rhs._value))
   }
 }
 
@@ -35,7 +35,7 @@ extension UInt8: ExpressibleByIntegerLiteral {
 
 extension UInt8: Equatable {
   @_transparent
-  public static func == (_ lhs: UInt8, _ rhs: UInt8) -> Bool {
+  public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
     return Bool(Builtin.cmp_eq_Int8(lhs._value, rhs._value))
   }
 }


### PR DESCRIPTION
This homogenises more of the operations on the integer types to use the proper
labels for paramters.  Additionally, use `Self` more aggressively for the
type.