### PR TITLE
Core: add `SignedNumeric` protocol

### DIFF
--- a/Sources/Core/CMakeLists.txt
+++ b/Sources/Core/CMakeLists.txt
@@ -33,6 +33,7 @@ add_library(swiftCore
   Range.swift
   RangeExpression.swift
   Sequence.swift
+  SignedNumeric.swift
   StaticString.swift
   Swift.swift
   UInt.swift

--- a/Sources/Core/Operators.swift
+++ b/Sources/Core/Operators.swift
@@ -59,6 +59,7 @@ precedencegroup BitwiseShiftPrecedence {
 }
 
 prefix operator !
+prefix operator -
 
 infix operator ==: ComparisonPrecedence
 infix operator !=: ComparisonPrecedence

--- a/Sources/Core/SignedNumeric.swift
+++ b/Sources/Core/SignedNumeric.swift
@@ -7,3 +7,8 @@ public protocol SignedNumeric: Numeric {
 
   mutating func negate()
 }
+
+// FIXME: extension with default implementations of `prefix func -` and
+// `negate()` are missing. This extension currently causes assertions in the
+// type checker. We assume that this is caused by our iterative approach, which
+// temporarily excluded certain requirements from previously added protocols.

--- a/Sources/Core/SignedNumeric.swift
+++ b/Sources/Core/SignedNumeric.swift
@@ -8,7 +8,7 @@ public protocol SignedNumeric: Numeric {
   mutating func negate()
 }
 
-// FIXME: extension with default implementations of `prefix func -` and
+// FIXME(MaxDesiatov): extension with default implementations of `prefix func -` and
 // `negate()` are missing. This extension currently causes assertions in the
 // type checker. We assume that this is caused by our iterative approach, which
 // temporarily excluded certain requirements from previously added protocols.

--- a/Sources/Core/SignedNumeric.swift
+++ b/Sources/Core/SignedNumeric.swift
@@ -1,0 +1,9 @@
+// Copyright © 2022 Max Desiatov <max@desiatov.com>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
+
+public protocol SignedNumeric: Numeric {
+  static prefix func - (_ operand: Self) -> Self
+
+  mutating func negate()
+}


### PR DESCRIPTION
Depends on #55.

I'm not adding the default (and only) implementation here yet, as it crashes the type checker with `Assertion failed: (protocol && "requirements should have stopped recursion")` error message:

```swift
extension SignedNumeric {
  @_transparent
  public static prefix func - (_ operand: Self) -> Self {
    var result = operand
    result.negate()
    return result
  }

  @_transparent
  public mutating func negate() {
    self = 0 - self
  }
}
```