### PR TITLE
Set ruler to 80 columns in `.vscode/settings.json`

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "editor.rulers": [80]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
 {
-  "editor.rulers": [80]
+  "editor.rulers": [80],
+  "swiftformat.enable": false
 }


### PR DESCRIPTION
I haven't been able to find satisfying formatting options for SwiftFormat yet, so disabling it for now.