### PR TITLE
Re-enable SwiftFormat, add config file

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -1,0 +1,6 @@
+--disable redundantReturn
+--maxwidth 80
+--closingparen same-line
+--emptybraces linebreak
+--disable wrapMultilineStatementBraces
+--redundanttype explicit

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,3 @@
 {
-  "editor.rulers": [80],
-  "swiftformat.enable": false
+  "editor.rulers": [80]
 }


### PR DESCRIPTION
After tweaking a few settings, I think I actually found a combination of options that lines up function parameters as needed.