### PR TITLE
vscode: add some more default settings and suggestions

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,7 @@
+{
+  "recommendations": [
+    "exodiusstudios.comment-anchors",
+    "ms-vscode.cmake-tools",
+    "twxs.cmake",
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,37 @@
 {
-  "editor.rulers": [80]
+  "cmake.configureOnOpen": false,
+  "commentAnchors.tags.list": [
+    {
+      "tag": "MARK",
+      "iconColor": "default",
+      "highlightColor": "#A8C023",
+      "scope": "file",
+    },
+    {
+      "tag": "TODO",
+      "iconColor": "blue",
+      "highlightColor": "#3ea8ff",
+      "scope": "workspace",
+    },
+    {
+      "tag": "FIXME",
+      "iconColor": "red",
+      "highlightColor": "#f44336",
+      "scope": "workspace",
+    },
+    {
+      "tag": "NOTE",
+      "iconColor": "orange",
+      "highlightColor": "#ffb300",
+      "scope": "file",
+    },
+  ],
+  "editor.rulers": [80],
+  "files.exclude" : {
+    ".git": true,
+    ".build": true,
+    "**/.*.sw?": true,
+    "**/.DS_Store": true,
+    "out": true,
+  },
 }


### PR DESCRIPTION
Avoid the automated cmake configure request on project open, exclude some files
from the file list, and add suggestions for CMake syntax highlighting, CMake
integration, and comment anchor extensions. The latter allows highlighting
specific tags.  Configure the default set of tags to highlight to include
"MARK", "TODO", "FIXME", "NOTE".