### PR TITLE
SwiftFormat: tweak function arguments wrapping

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -4,3 +4,4 @@
 --emptybraces linebreak
 --disable wrapMultilineStatementBraces
 --redundanttype explicit
+--wraparguments after-first


### PR DESCRIPTION
This makes it more consistent with the rest of the codebase.