### PR TITLE
Runtime: fix missing return value warning

### DIFF
--- a/Sources/Runtime/HeapObject.c
+++ b/Sources/Runtime/HeapObject.c
@@ -11,7 +11,9 @@ SWIFT_RUNTIME_ABI
 HeapObject *swift_retain(HeapObject *object) { return NULL; }
 
 SWIFT_RUNTIME_ABI
-void *swift_slowAlloc(size_t bytes, size_t alignMask) {}
+void *swift_slowAlloc(size_t bytes, size_t alignMask) { 
+  return NULL; 
+}
 
 SWIFT_RUNTIME_ABI
 void swift_slowDealloc(void *ptr, size_t bytes, size_t alignMask) {}


### PR DESCRIPTION
`swift_slowAlloc` is supposed to return a pointer.