### PR TITLE
Core: adjust style for `{,U}Int{,8,32}`

### DIFF
--- a/Sources/Core/Int.swift
+++ b/Sources/Core/Int.swift
@@ -30,7 +30,33 @@ extension Int: _ExpressibleByBuiltinIntegerLiteral {
   }
 }
 
-extension Int: ExpressibleByIntegerLiteral {
+extension Int: AdditiveArithmetic {
+  @_transparent
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.sadd_with_overflow_Word(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+
+  @_transparent
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.ssub_with_overflow_Word(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+}
+
+extension Int: Comparable {
+  @_transparent
+  public static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_slt_Word(lhs._value, rhs._value))
+  }
 }
 
 extension Int: Equatable {
@@ -40,46 +66,17 @@ extension Int: Equatable {
   }
 }
 
-extension Int: AdditiveArithmetic {
-  @_transparent
-  public static func + (_ lhs: Int, _ rhs: Int) -> Int {
-    let (result, overflow) =
-        Builtin.sadd_with_overflow_Word(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return Int(result)
-  }
-
-  @_transparent
-  public static func - (_ lhs: Int, _ rhs: Int) -> Int {
-    let (result, overflow) =
-        Builtin.ssub_with_overflow_Word(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return Int(result)
-  }
+extension Int: ExpressibleByIntegerLiteral {
 }
 
 extension Int: Numeric {
   @_transparent
-  public static func * (_ lhs: Int, _ rhs: Int) -> Int {
+  public static func * (_ lhs: Self, _ rhs: Self) -> Self {
     let (result, overflow) =
         Builtin.smul_with_overflow_Word(lhs._value, rhs._value, true._value)
-
     Builtin.condfail_message(overflow,
                              StaticString("arithmetic overflow")
                                .unsafeRawPointer)
-    return Int(result)
-  }
-}
-
-extension Int: Comparable {
-  @_transparent
-  public static func < (_ lhs: Int, _ rhs: Int) -> Bool {
-    return Bool(Builtin.cmp_slt_Word(lhs._value, rhs._value))
+    return Self(result)
   }
 }

--- a/Sources/Core/Int32.swift
+++ b/Sources/Core/Int32.swift
@@ -30,7 +30,33 @@ extension Int32: _ExpressibleByBuiltinIntegerLiteral {
   }
 }
 
-extension Int32: ExpressibleByIntegerLiteral {
+extension Int32: AdditiveArithmetic {
+  @_transparent
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.sadd_with_overflow_Int32(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+
+  @_transparent
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.ssub_with_overflow_Int32(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+}
+
+extension Int32: Comparable {
+  @_transparent
+  public static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_slt_Int32(lhs._value, rhs._value))
+  }
 }
 
 extension Int32: Equatable {
@@ -40,46 +66,17 @@ extension Int32: Equatable {
   }
 }
 
-extension Int32: AdditiveArithmetic {
-  @_transparent
-  public static func + (_ lhs: Int32, _ rhs: Int32) -> Int32 {
-    let (result, overflow) =
-        Builtin.sadd_with_overflow_Int32(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return Int32(result)
-  }
-
-  @_transparent
-  public static func - (_ lhs: Int32, _ rhs: Int32) -> Int32 {
-    let (result, overflow) =
-        Builtin.ssub_with_overflow_Int32(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return Int32(result)
-  }
+extension Int32: ExpressibleByIntegerLiteral {
 }
 
 extension Int32: Numeric {
   @_transparent
-  public static func * (_ lhs: Int32, _ rhs: Int32) -> Int32 {
+  public static func * (_ lhs: Self, _ rhs: Self) -> Self {
     let (result, overflow) =
         Builtin.smul_with_overflow_Int32(lhs._value, rhs._value, true._value)
-
     Builtin.condfail_message(overflow,
                              StaticString("arithmetic overflow")
                                .unsafeRawPointer)
-    return Int32(result)
-  }
-}
-
-extension Int32: Comparable {
-  @_transparent
-  public static func < (_ lhs: Int32, _ rhs: Int32) -> Bool {
-    return Bool(Builtin.cmp_slt_Int32(lhs._value, rhs._value))
+    return Self(result)
   }
 }

--- a/Sources/Core/Int8.swift
+++ b/Sources/Core/Int8.swift
@@ -30,7 +30,33 @@ extension Int8: _ExpressibleByBuiltinIntegerLiteral {
   }
 }
 
-extension Int8: ExpressibleByIntegerLiteral {
+extension Int8: AdditiveArithmetic {
+  @_transparent
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.sadd_with_overflow_Int8(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+
+  @_transparent
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.ssub_with_overflow_Int8(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+}
+
+extension Int8: Comparable {
+  @_transparent
+  public static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_slt_Int8(lhs._value, rhs._value))
+  }
 }
 
 extension Int8: Equatable {
@@ -40,46 +66,17 @@ extension Int8: Equatable {
   }
 }
 
-extension Int8: AdditiveArithmetic {
-  @_transparent
-  public static func + (_ lhs: Int8, _ rhs: Int8) -> Int8 {
-    let (result, overflow) =
-        Builtin.sadd_with_overflow_Int8(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return Int8(result)
-  }
-
-  @_transparent
-  public static func - (_ lhs: Int8, _ rhs: Int8) -> Int8 {
-    let (result, overflow) =
-        Builtin.ssub_with_overflow_Int8(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return Int8(result)
-  }
+extension Int8: ExpressibleByIntegerLiteral {
 }
 
 extension Int8: Numeric {
   @_transparent
-  public static func * (_ lhs: Int8, _ rhs: Int8) -> Int8 {
+  public static func * (_ lhs: Self, _ rhs: Self) -> Self {
     let (result, overflow) =
         Builtin.smul_with_overflow_Int8(lhs._value, rhs._value, true._value)
-
     Builtin.condfail_message(overflow,
                              StaticString("arithmetic overflow")
                                .unsafeRawPointer)
-    return Int8(result)
-  }
-}
-
-extension Int8: Comparable {
-  @_transparent
-  public static func < (_ lhs: Int8, _ rhs: Int8) -> Bool {
-    return Bool(Builtin.cmp_slt_Int8(lhs._value, rhs._value))
+    return Self(result)
   }
 }

--- a/Sources/Core/UInt.swift
+++ b/Sources/Core/UInt.swift
@@ -30,7 +30,33 @@ extension UInt: _ExpressibleByBuiltinIntegerLiteral {
   }
 }
 
-extension UInt: ExpressibleByIntegerLiteral {
+extension UInt: AdditiveArithmetic {
+  @_transparent
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.uadd_with_overflow_Word(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+
+  @_transparent
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.usub_with_overflow_Word(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+}
+
+extension UInt: Comparable {
+  @_transparent
+  public static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_ult_Word(lhs._value, rhs._value))
+  }
 }
 
 extension UInt: Equatable {
@@ -40,46 +66,17 @@ extension UInt: Equatable {
   }
 }
 
-extension UInt: AdditiveArithmetic {
-  @_transparent
-  public static func + (_ lhs: UInt, _ rhs: UInt) -> UInt {
-    let (result, overflow) =
-        Builtin.uadd_with_overflow_Word(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return UInt(result)
-  }
-
-  @_transparent
-  public static func - (_ lhs: UInt, _ rhs: UInt) -> UInt {
-    let (result, overflow) =
-        Builtin.usub_with_overflow_Word(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return UInt(result)
-  }
+extension UInt: ExpressibleByIntegerLiteral {
 }
 
 extension UInt: Numeric {
   @_transparent
-  public static func * (_ lhs: UInt, _ rhs: UInt) -> UInt {
+  public static func * (_ lhs: Self, _ rhs: Self) -> Self {
     let (result, overflow) =
         Builtin.umul_with_overflow_Word(lhs._value, rhs._value, true._value)
-
     Builtin.condfail_message(overflow,
                              StaticString("arithmetic overflow")
                                .unsafeRawPointer)
-    return UInt(result)
-  }
-}
-
-extension UInt: Comparable {
-  @_transparent
-  public static func < (_ lhs: UInt, _ rhs: UInt) -> Bool {
-    return Bool(Builtin.cmp_ult_Word(lhs._value, rhs._value))
+    return Self(result)
   }
 }

--- a/Sources/Core/UInt32.swift
+++ b/Sources/Core/UInt32.swift
@@ -30,7 +30,33 @@ extension UInt32: _ExpressibleByBuiltinIntegerLiteral {
   }
 }
 
-extension UInt32: ExpressibleByIntegerLiteral {
+extension UInt32: AdditiveArithmetic {
+  @_transparent
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.uadd_with_overflow_Int32(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+
+  @_transparent
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.usub_with_overflow_Int32(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+}
+
+extension UInt32: Comparable {
+  @_transparent
+  public static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_ult_Int32(lhs._value, rhs._value))
+  }
 }
 
 extension UInt32: Equatable {
@@ -40,46 +66,17 @@ extension UInt32: Equatable {
   }
 }
 
-extension UInt32: AdditiveArithmetic {
-  @_transparent
-  public static func + (_ lhs: UInt32, _ rhs: UInt32) -> UInt32 {
-    let (result, overflow) =
-        Builtin.uadd_with_overflow_Int32(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return UInt32(result)
-  }
-
-  @_transparent
-  public static func - (_ lhs: UInt32, _ rhs: UInt32) -> UInt32 {
-    let (result, overflow) =
-        Builtin.usub_with_overflow_Int32(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return UInt32(result)
-  }
+extension UInt32: ExpressibleByIntegerLiteral {
 }
 
 extension UInt32: Numeric {
   @_transparent
-  public static func * (_ lhs: UInt32, _ rhs: UInt32) -> UInt32 {
+  public static func * (_ lhs: Self, _ rhs: Self) -> Self {
     let (result, overflow) =
         Builtin.umul_with_overflow_Int32(lhs._value, rhs._value, true._value)
-
     Builtin.condfail_message(overflow,
                              StaticString("arithmetic overflow")
                                .unsafeRawPointer)
-    return UInt32(result)
-  }
-}
-
-extension UInt32: Comparable {
-  @_transparent
-  public static func < (_ lhs: UInt32, _ rhs: UInt32) -> Bool {
-    return Bool(Builtin.cmp_ult_Int32(lhs._value, rhs._value))
+    return Self(result)
   }
 }

--- a/Sources/Core/UInt8.swift
+++ b/Sources/Core/UInt8.swift
@@ -30,7 +30,33 @@ extension UInt8: _ExpressibleByBuiltinIntegerLiteral {
   }
 }
 
-extension UInt8: ExpressibleByIntegerLiteral {
+extension UInt8: AdditiveArithmetic {
+  @_transparent
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.uadd_with_overflow_Int8(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+
+  @_transparent
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.usub_with_overflow_Int8(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                               .unsafeRawPointer)
+    return Self(result)
+  }
+}
+
+extension UInt8: Comparable {
+  @_transparent
+  public static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_ult_Int8(lhs._value, rhs._value))
+  }
 }
 
 extension UInt8: Equatable {
@@ -40,46 +66,17 @@ extension UInt8: Equatable {
   }
 }
 
-extension UInt8: AdditiveArithmetic {
-  @_transparent
-  public static func + (_ lhs: UInt8, _ rhs: UInt8) -> UInt8 {
-    let (result, overflow) =
-        Builtin.uadd_with_overflow_Int8(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return UInt8(result)
-  }
-
-  @_transparent
-  public static func - (_ lhs: UInt8, _ rhs: UInt8) -> UInt8 {
-    let (result, overflow) =
-        Builtin.usub_with_overflow_Int8(lhs._value, rhs._value, true._value)
-
-    Builtin.condfail_message(overflow,
-                             StaticString("arithmetic overflow")
-                               .unsafeRawPointer)
-    return UInt8(result)
-  }
+extension UInt8: ExpressibleByIntegerLiteral {
 }
 
 extension UInt8: Numeric {
   @_transparent
-  public static func * (_ lhs: UInt8, _ rhs: UInt8) -> UInt8 {
+  public static func * (_ lhs: Self, _ rhs: Self) -> Self {
     let (result, overflow) =
         Builtin.umul_with_overflow_Int8(lhs._value, rhs._value, true._value)
-
     Builtin.condfail_message(overflow,
                              StaticString("arithmetic overflow")
                                .unsafeRawPointer)
-    return UInt8(result)
-  }
-}
-
-extension UInt8: Comparable {
-  @_transparent
-  public static func < (_ lhs: UInt8, _ rhs: UInt8) -> Bool {
-    return Bool(Builtin.cmp_ult_Int8(lhs._value, rhs._value))
+    return Self(result)
   }
 }


### PR DESCRIPTION
This sorts the extensions lexicographically to make it easier to locate the
extension.  Additionally, more aggressively use `Self` for the conformances
which illustrates the values are meant to be the same "generic" type.