### PR TITLE
SwiftFormat: tweak extensions ACL formatting

### DIFF
--- a/.swiftformat
+++ b/.swiftformat
@@ -5,3 +5,4 @@
 --disable wrapMultilineStatementBraces
 --redundanttype explicit
 --wraparguments after-first
+--extensionacl on-declarations


### PR DESCRIPTION
This matches the coding style of the project with ACL modifiers on specific declarations instead of grouping ACL with `public extension`.