### PR TITLE
Core: reflow text in CompilerProtocols (NFC)

### DIFF
--- a/Sources/Core/CompilerProtocols.swift
+++ b/Sources/Core/CompilerProtocols.swift
@@ -40,7 +40,8 @@ public protocol RawRepresentable {
 }
 
 public protocol _ExpressibleByBuiltinStringLiteral {
-  init(_builtinStringLiteral start: Builtin.RawPointer, utf8CodeUnitCount: Builtin.Word, isASCII: Builtin.Int1)
+  init(_builtinStringLiteral start: Builtin.RawPointer,
+       utf8CodeUnitCount: Builtin.Word, isASCII: Builtin.Int1)
 }
 
 public protocol ExpressibleByStringLiteral {


### PR DESCRIPTION
Reflow an overly long line to adhere to 80-columns.