### PR TITLE
Core: introduce `Int64` and `UInt64`

### DIFF
--- a/Sources/Core/CMakeLists.txt
+++ b/Sources/Core/CMakeLists.txt
@@ -21,6 +21,7 @@ add_library(swiftCore
   Int8.swift
   Int16.swift
   Int32.swift
+  Int64.swift
   Integers.swift
   IteratorProtocol.swift
   Lifetime.swift
@@ -40,6 +41,7 @@ add_library(swiftCore
   UInt8.swift
   UInt16.swift
   UInt32.swift
+  UInt64.swift
   UnsafeMutablePointer.swift
   UnsafeMutableRawPointer.swift
   UnsafePointer.swift

--- a/Sources/Core/Int64.swift
+++ b/Sources/Core/Int64.swift
@@ -1,0 +1,82 @@
+// Copyright © 2022 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
+
+@frozen
+public struct Int64 {
+  @usableFromInline
+  internal var _value: Builtin.Int64
+
+  @_transparent
+  public init(_ _value: Builtin.Int64) {
+    self._value = _value
+  }
+
+  @_transparent
+  public static func &= (_ lhs: inout Self, _ rhs: Self) {
+    lhs = lhs & rhs
+  }
+
+  @_transparent
+  public static func & (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(Builtin.and_Int64(lhs._value, rhs._value))
+  }
+}
+
+extension Int64: _ExpressibleByBuiltinIntegerLiteral {
+  @_transparent
+  public init(_builtinIntegerLiteral value: Builtin.IntLiteral) {
+    _value = Builtin.s_to_s_checked_trunc_IntLiteral_Int64(value).0
+  }
+}
+
+extension Int64: AdditiveArithmetic {
+  @_transparent
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) = 
+        Builtin.sadd_with_overflow_Int64(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Self(result)
+  }
+
+  @_transparent
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.ssub_with_overflow_Int64(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Self(result)
+  }
+}
+
+extension Int64: Comparable {
+  @_transparent
+  public static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_slt_Int64(lhs._value, rhs._value))
+  }
+}
+
+extension Int64: Equatable {
+  @_transparent
+  public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_eq_Int64(lhs._value, rhs._value))
+  }
+}
+
+extension Int64: ExpressibleByIntegerLiteral {
+}
+
+extension Int64: Numeric {
+  @_transparent
+  public static func * (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.smul_with_overflow_Int64(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Self(result)
+  }
+}

--- a/Sources/Core/UInt64.swift
+++ b/Sources/Core/UInt64.swift
@@ -1,0 +1,82 @@
+// Copyright © 2022 Saleem Abdulrasool <compnerd@compnerd.org>.
+// All Rights Reserved.
+// SPDX-License-Identifier: BSD-3
+
+@frozen
+public struct UInt64 {
+  @usableFromInline
+  internal var _value: Builtin.Int64
+
+  @_transparent
+  public init(_ _value: Builtin.Int64) {
+    self._value = _value
+  }
+
+  @_transparent
+  public static func &= (_ lhs: inout Self, _ rhs: Self) {
+    lhs = lhs & rhs
+  }
+
+  @_transparent
+  public static func & (_ lhs: Self, _ rhs: Self) -> Self {
+    return Self(Builtin.and_Int64(lhs._value, rhs._value))
+  }
+}
+
+extension UInt64: _ExpressibleByBuiltinIntegerLiteral {
+  @_transparent
+  public init(_builtinIntegerLiteral value: Builtin.IntLiteral) {
+    _value = Builtin.s_to_s_checked_trunc_IntLiteral_Int64(value).0
+  }
+}
+
+extension UInt64: AdditiveArithmetic {
+  @_transparent
+  public static func + (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) = 
+        Builtin.sadd_with_overflow_Int64(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Self(result)
+  }
+
+  @_transparent
+  public static func - (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.ssub_with_overflow_Int64(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Self(result)
+  }
+}
+
+extension UInt64: Comparable {
+  @_transparent
+  public static func < (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_slt_Int64(lhs._value, rhs._value))
+  }
+}
+
+extension UInt64: Equatable {
+  @_transparent
+  public static func == (_ lhs: Self, _ rhs: Self) -> Bool {
+    return Bool(Builtin.cmp_eq_Int64(lhs._value, rhs._value))
+  }
+}
+
+extension UInt64: ExpressibleByIntegerLiteral {
+}
+
+extension UInt64: Numeric {
+  @_transparent
+  public static func * (_ lhs: Self, _ rhs: Self) -> Self {
+    let (result, overflow) =
+        Builtin.smul_with_overflow_Int64(lhs._value, rhs._value, true._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Self(result)
+  }
+}


### PR DESCRIPTION
This completes the built-in sized integer types.  We now have the fixed-size
integers as well as the word sized integer types.