### PR TITLE
build: correct the linking of swiftCore

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,12 @@ cmake_minimum_required(VERSION 3.18)
 project(uSwift
   LANGUAGES C Swift)
 
+# TODO(compnerd) we should only filter out ld.bfd (ld) and support both gold and
+# lld as valid options.
+if(NOT CMAKE_SYSTEM_NAME MATCHES Windows AND NOT CMAKE_SYSTEM_NAME MATCHES Darwin)
+  add_link_options($<$<LINK_LANGUAGE:C,CXX>:-fuse-ld=gold>)
+endif()
+
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)

--- a/Sources/Core/CMakeLists.txt
+++ b/Sources/Core/CMakeLists.txt
@@ -50,6 +50,7 @@ add_library(swiftCore
   UnsafeRawPointer.swift
   Void.swift)
 set_target_properties(swiftCore PROPERTIES
+  LINKER_LANGUAGE C
   Swift_MODULE_NAME Swift)
 target_compile_options(swiftCore PRIVATE
   -parse-stdlib
@@ -58,4 +59,4 @@ target_compile_options(swiftCore PRIVATE
 target_link_libraries(swiftCore PRIVATE
   swiftRuntime)
 target_link_options(swiftCore PRIVATE
-  "SHELL:-Xclang-linker -nostdlib")
+  -nostdlib)


### PR DESCRIPTION
This fixes the configuration of the build to build the swiftCore shared library
properly.  We should treat the library as being a C (or C++) library.  This
ensures that we use the C/C++ linker driver to link the library rather than the
Swift linker driver.  This will avoid the incorrect embedding of the Swift
registrar for non-Darwin targets.