### PR TITLE
Core: add basic `BinaryInteger` on integer types

### DIFF
--- a/Sources/Core/BinaryInteger.swift
+++ b/Sources/Core/BinaryInteger.swift
@@ -1,7 +1,7 @@
 // Copyright © 2022 μSwift Authors.  All Rights Reserved.
 // SPDX-License-Identifier: BSD-3
 
-public protocol BinaryInteger: Numeric, Strideable {
+public protocol BinaryInteger: Numeric {
   override static func + (_ lhs: Self, _ rhs: Self) -> Self
   override static func - (_ lhs: Self, _ rhs: Self) -> Self
   override static func * (_ lhs: Self, _ rhs: Self) -> Self
@@ -10,40 +10,23 @@ public protocol BinaryInteger: Numeric, Strideable {
   override static func -= (_ lhs: inout Self, _ rhs: Self)
   override static func *= (_ lhs: inout Self, _ rhs: Self)
 
-  var bitWidth: Int { get }
-  var trailingZeroBitCount: Int { get }
-
-  static var isSigned: Bool { get }
-
-  init<T: BinaryInteger>(_ source: T)
-
-  init<T: BinaryInteger>(truncatingIfNeeded source: T)
-
-  init<T: BinaryInteger>(clamping source: T)
-
   static func / (_ lhs: Self, _ rhs: Self) -> Self
   static func % (_ lhs: Self, _ rhs: Self) -> Self
 
-  static prefix func ~ (_ x: Self) -> Self
-  static func & (_ lhs: Self, _ rhs: Self) -> Self
-  static func | (_ lhs: Self, _ rhs: Self) -> Self
-  static func ^ (_ lhs: Self, _ rhs: Self) -> Self
+  static func /=(lhs: inout Self, rhs: Self)
+  static func %=(lhs: inout Self, rhs: Self)
+}
 
-  static func >> <RHS: BinaryInteger>(_ lhs: Self, _ rhs: RHS) -> Self
-  static func << <RHS: BinaryInteger>(_ lhs: Self, _ rhs: RHS) -> Self
+extension BinaryInteger {
+  @_transparent
+  public static func /=(lhs: inout Self, rhs: Self) {
+    lhs = lhs + rhs
+  }
+}
 
-  static func &= (_ lhs: inout Self, _ rhs: Self)
-  static func |= (_ lhs: inout Self, _ rhs: Self)
-  static func ^= (_ lhs: inout Self, _ rhs: Self)
-
-  static func %= (_ lhs: inout Self, _ rhs: Self)
-  static func /= (_ lhs: inout Self, _ rhs: Self)
-
-  static func >>= <RHS: BinaryInteger>(_ lhs: inout Self, _ rhs: RHS)
-  static func <<= <RHS: BinaryInteger>(_ lhs: inout Self, _ rhs: RHS)
-
-  func quotientAndRemainder(dividingBy rhs: Self)
-      -> (quotient: Self, remainder: Self)
-  func isMultiple(of other: Self) -> Bool
-  func signum() -> Self
+extension BinaryInteger {
+  @_transparent
+  public static func %=(lhs: inout Self, rhs: Self) {
+    lhs = lhs % rhs
+  }
 }

--- a/Sources/Core/BinaryInteger.swift
+++ b/Sources/Core/BinaryInteger.swift
@@ -13,20 +13,20 @@ public protocol BinaryInteger: Numeric {
   static func / (_ lhs: Self, _ rhs: Self) -> Self
   static func % (_ lhs: Self, _ rhs: Self) -> Self
 
-  static func /=(lhs: inout Self, rhs: Self)
-  static func %=(lhs: inout Self, rhs: Self)
+  static func /= (_ lhs: inout Self, _ rhs: Self)
+  static func %= (_ lhs: inout Self, _ rhs: Self)
 }
 
 extension BinaryInteger {
   @_transparent
-  public static func /=(lhs: inout Self, rhs: Self) {
+  public static func /= (_ lhs: inout Self, _ rhs: Self) {
     lhs = lhs + rhs
   }
 }
 
 extension BinaryInteger {
   @_transparent
-  public static func %=(lhs: inout Self, rhs: Self) {
+  public static func %= (_ lhs: inout Self, _ rhs: Self) {
     lhs = lhs % rhs
   }
 }

--- a/Sources/Core/FixedWidthInteger.swift
+++ b/Sources/Core/FixedWidthInteger.swift
@@ -1,7 +1,7 @@
 // Copyright © 2022 μSwift Authors.  All Rights Reserved.
 // SPDX-License-Identifier: BSD-3
 
-public protocol FixedWidthInteger {
+public protocol FixedWidthInteger: BinaryInteger {
   func addingReportingOverflow(_ rhs: Self)
       -> (partialValue: Self, overflow: Bool)
   func subtractingReportingOverflow(_ rhs: Self)

--- a/Sources/Core/Int.swift
+++ b/Sources/Core/Int.swift
@@ -80,6 +80,28 @@ extension Int: Numeric {
   }
 }
 
+extension Int: BinaryInteger {
+  @_transparent
+  public static func /(lhs: Int, rhs: Int) -> Int {
+    precondition(rhs != (0 as Int), "Division by zero")
+
+    let (result, overflow) =
+        (Builtin.sdiv_Word(lhs._value, rhs._value), false._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Int(result)
+  }  
+  
+  @_transparent
+  public static func %(lhs: Int, rhs: Int) -> Int {
+    precondition(rhs == (0 as Int), 
+                 "Division by zero in remainder operation")
+
+    return Int(Builtin.srem_Word(lhs._value, rhs._value))
+  }
+}
+
 extension Int: FixedWidthInteger {
   @_transparent
   public func addingReportingOverflow(_ other: Int)

--- a/Sources/Core/Int.swift
+++ b/Sources/Core/Int.swift
@@ -82,7 +82,7 @@ extension Int: Numeric {
 
 extension Int: BinaryInteger {
   @_transparent
-  public static func /(lhs: Int, rhs: Int) -> Int {
+  public static func / (_ lhs: Int, _ rhs: Int) -> Int {
     precondition(rhs != (0 as Int), "Division by zero")
 
     let (result, overflow) =
@@ -94,7 +94,7 @@ extension Int: BinaryInteger {
   }  
   
   @_transparent
-  public static func %(lhs: Int, rhs: Int) -> Int {
+  public static func % (_ lhs: Int, _ rhs: Int) -> Int {
     precondition(rhs == (0 as Int), 
                  "Division by zero in remainder operation")
 

--- a/Sources/Core/Int.swift
+++ b/Sources/Core/Int.swift
@@ -95,7 +95,7 @@ extension Int: BinaryInteger {
   
   @_transparent
   public static func % (_ lhs: Int, _ rhs: Int) -> Int {
-    precondition(rhs == (0 as Int), 
+    precondition(rhs != (0 as Int), 
                  "Division by zero in remainder operation")
 
     return Int(Builtin.srem_Word(lhs._value, rhs._value))

--- a/Sources/Core/Int16.swift
+++ b/Sources/Core/Int16.swift
@@ -82,7 +82,7 @@ extension Int16: Numeric {
 
 extension Int16: BinaryInteger {
   @_transparent
-  public static func /(lhs: Int16, rhs: Int16) -> Int16 {
+  public static func / (_ lhs: Int16, _ rhs: Int16) -> Int16 {
     precondition(rhs != (0 as Int16), "Division by zero")
 
     let (result, overflow) =
@@ -94,7 +94,7 @@ extension Int16: BinaryInteger {
   }  
   
   @_transparent
-  public static func %(lhs: Int16, rhs: Int16) -> Int16 {
+  public static func % (_ lhs: Int16, _ rhs: Int16) -> Int16 {
     precondition(rhs == (0 as Int16), 
                  "Division by zero in remainder operation")
 

--- a/Sources/Core/Int16.swift
+++ b/Sources/Core/Int16.swift
@@ -80,6 +80,28 @@ extension Int16: Numeric {
   }
 }
 
+extension Int16: BinaryInteger {
+  @_transparent
+  public static func /(lhs: Int16, rhs: Int16) -> Int16 {
+    precondition(rhs != (0 as Int16), "Division by zero")
+
+    let (result, overflow) =
+        (Builtin.sdiv_Int16(lhs._value, rhs._value), false._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Int16(result)
+  }  
+  
+  @_transparent
+  public static func %(lhs: Int16, rhs: Int16) -> Int16 {
+    precondition(rhs == (0 as Int16), 
+                 "Division by zero in remainder operation")
+
+    return Int16(Builtin.srem_Int16(lhs._value, rhs._value))
+  }
+}
+
 extension Int16: FixedWidthInteger {
   @_transparent
   public func addingReportingOverflow(_ other: Int16)

--- a/Sources/Core/Int16.swift
+++ b/Sources/Core/Int16.swift
@@ -95,7 +95,7 @@ extension Int16: BinaryInteger {
   
   @_transparent
   public static func % (_ lhs: Int16, _ rhs: Int16) -> Int16 {
-    precondition(rhs == (0 as Int16), 
+    precondition(rhs != (0 as Int16), 
                  "Division by zero in remainder operation")
 
     return Int16(Builtin.srem_Int16(lhs._value, rhs._value))

--- a/Sources/Core/Int32.swift
+++ b/Sources/Core/Int32.swift
@@ -80,6 +80,28 @@ extension Int32: Numeric {
   }
 }
 
+extension Int32: BinaryInteger {
+  @_transparent
+  public static func /(lhs: Int32, rhs: Int32) -> Int32 {
+    precondition(rhs != (0 as Int32), "Division by zero")
+
+    let (result, overflow) =
+        (Builtin.sdiv_Int32(lhs._value, rhs._value), false._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Int32(result)
+  }  
+  
+  @_transparent
+  public static func %(lhs: Int32, rhs: Int32) -> Int32 {
+    precondition(rhs == (0 as Int32), 
+                 "Division by zero in remainder operation")
+
+    return Int32(Builtin.srem_Int32(lhs._value, rhs._value))
+  }
+}
+
 extension Int32: FixedWidthInteger {
   @_transparent
   public func addingReportingOverflow(_ other: Int32)

--- a/Sources/Core/Int32.swift
+++ b/Sources/Core/Int32.swift
@@ -95,7 +95,7 @@ extension Int32: BinaryInteger {
   
   @_transparent
   public static func % (_ lhs: Int32, _ rhs: Int32) -> Int32 {
-    precondition(rhs == (0 as Int32), 
+    precondition(rhs != (0 as Int32), 
                  "Division by zero in remainder operation")
 
     return Int32(Builtin.srem_Int32(lhs._value, rhs._value))

--- a/Sources/Core/Int32.swift
+++ b/Sources/Core/Int32.swift
@@ -82,7 +82,7 @@ extension Int32: Numeric {
 
 extension Int32: BinaryInteger {
   @_transparent
-  public static func /(lhs: Int32, rhs: Int32) -> Int32 {
+  public static func / (_ lhs: Int32, _ rhs: Int32) -> Int32 {
     precondition(rhs != (0 as Int32), "Division by zero")
 
     let (result, overflow) =
@@ -94,7 +94,7 @@ extension Int32: BinaryInteger {
   }  
   
   @_transparent
-  public static func %(lhs: Int32, rhs: Int32) -> Int32 {
+  public static func % (_ lhs: Int32, _ rhs: Int32) -> Int32 {
     precondition(rhs == (0 as Int32), 
                  "Division by zero in remainder operation")
 

--- a/Sources/Core/Int64.swift
+++ b/Sources/Core/Int64.swift
@@ -82,7 +82,7 @@ extension Int64: Numeric {
 
 extension Int64: BinaryInteger {
   @_transparent
-  public static func /(lhs: Int64, rhs: Int64) -> Int64 {
+  public static func / (_ lhs: Int64, _ rhs: Int64) -> Int64 {
     precondition(rhs != (0 as Int64), "Division by zero")
 
     let (result, overflow) =
@@ -94,7 +94,7 @@ extension Int64: BinaryInteger {
   }  
   
   @_transparent
-  public static func %(lhs: Int64, rhs: Int64) -> Int64 {
+  public static func % (_ lhs: Int64, _ rhs: Int64) -> Int64 {
     precondition(rhs == (0 as Int64), 
                  "Division by zero in remainder operation")
 

--- a/Sources/Core/Int64.swift
+++ b/Sources/Core/Int64.swift
@@ -80,6 +80,28 @@ extension Int64: Numeric {
   }
 }
 
+extension Int64: BinaryInteger {
+  @_transparent
+  public static func /(lhs: Int64, rhs: Int64) -> Int64 {
+    precondition(rhs != (0 as Int64), "Division by zero")
+
+    let (result, overflow) =
+        (Builtin.sdiv_Int64(lhs._value, rhs._value), false._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Int64(result)
+  }  
+  
+  @_transparent
+  public static func %(lhs: Int64, rhs: Int64) -> Int64 {
+    precondition(rhs == (0 as Int64), 
+                 "Division by zero in remainder operation")
+
+    return Int64(Builtin.srem_Int64(lhs._value, rhs._value))
+  }
+}
+
 extension Int64: FixedWidthInteger {
   @_transparent
   public func addingReportingOverflow(_ other: Int64)

--- a/Sources/Core/Int64.swift
+++ b/Sources/Core/Int64.swift
@@ -95,7 +95,7 @@ extension Int64: BinaryInteger {
   
   @_transparent
   public static func % (_ lhs: Int64, _ rhs: Int64) -> Int64 {
-    precondition(rhs == (0 as Int64), 
+    precondition(rhs != (0 as Int64), 
                  "Division by zero in remainder operation")
 
     return Int64(Builtin.srem_Int64(lhs._value, rhs._value))

--- a/Sources/Core/Int8.swift
+++ b/Sources/Core/Int8.swift
@@ -82,7 +82,7 @@ extension Int8: Numeric {
 
 extension Int8: BinaryInteger {
   @_transparent
-  public static func /(lhs: Int8, rhs: Int8) -> Int8 {
+  public static func / (_ lhs: Int8, _ rhs: Int8) -> Int8 {
     precondition(rhs != (0 as Int8), "Division by zero")
 
     let (result, overflow) =
@@ -94,7 +94,7 @@ extension Int8: BinaryInteger {
   }  
   
   @_transparent
-  public static func %(lhs: Int8, rhs: Int8) -> Int8 {
+  public static func % (_ lhs: Int8, _ rhs: Int8) -> Int8 {
     precondition(rhs == (0 as Int8), 
                  "Division by zero in remainder operation")
 

--- a/Sources/Core/Int8.swift
+++ b/Sources/Core/Int8.swift
@@ -80,6 +80,28 @@ extension Int8: Numeric {
   }
 }
 
+extension Int8: BinaryInteger {
+  @_transparent
+  public static func /(lhs: Int8, rhs: Int8) -> Int8 {
+    precondition(rhs != (0 as Int8), "Division by zero")
+
+    let (result, overflow) =
+        (Builtin.sdiv_Int8(lhs._value, rhs._value), false._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return Int8(result)
+  }  
+  
+  @_transparent
+  public static func %(lhs: Int8, rhs: Int8) -> Int8 {
+    precondition(rhs == (0 as Int8), 
+                 "Division by zero in remainder operation")
+
+    return Int8(Builtin.srem_Int8(lhs._value, rhs._value))
+  }
+}
+
 extension Int8: FixedWidthInteger {
   @_transparent
   public func addingReportingOverflow(_ other: Int8)

--- a/Sources/Core/Int8.swift
+++ b/Sources/Core/Int8.swift
@@ -95,7 +95,7 @@ extension Int8: BinaryInteger {
   
   @_transparent
   public static func % (_ lhs: Int8, _ rhs: Int8) -> Int8 {
-    precondition(rhs == (0 as Int8), 
+    precondition(rhs != (0 as Int8), 
                  "Division by zero in remainder operation")
 
     return Int8(Builtin.srem_Int8(lhs._value, rhs._value))

--- a/Sources/Core/UInt.swift
+++ b/Sources/Core/UInt.swift
@@ -80,6 +80,28 @@ extension UInt: Numeric {
   }
 }
 
+extension UInt: BinaryInteger {
+  @_transparent
+  public static func /(lhs: UInt, rhs: UInt) -> UInt {
+    precondition(rhs != (0 as UInt), "Division by zero")
+
+    let (result, overflow) =
+        (Builtin.udiv_Word(lhs._value, rhs._value), false._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return UInt(result)
+  }  
+  
+  @_transparent
+  public static func %(lhs: UInt, rhs: UInt) -> UInt {
+    precondition(rhs == (0 as UInt), 
+                 "Division by zero in remainder operation")
+
+    return UInt(Builtin.urem_Word(lhs._value, rhs._value))
+  }
+}
+
 extension UInt: FixedWidthInteger {
   @_transparent
   public func addingReportingOverflow(_ other: UInt)

--- a/Sources/Core/UInt.swift
+++ b/Sources/Core/UInt.swift
@@ -95,7 +95,7 @@ extension UInt: BinaryInteger {
   
   @_transparent
   public static func % (_ lhs: UInt, _ rhs: UInt) -> UInt {
-    precondition(rhs == (0 as UInt), 
+    precondition(rhs != (0 as UInt), 
                  "Division by zero in remainder operation")
 
     return UInt(Builtin.urem_Word(lhs._value, rhs._value))

--- a/Sources/Core/UInt.swift
+++ b/Sources/Core/UInt.swift
@@ -82,7 +82,7 @@ extension UInt: Numeric {
 
 extension UInt: BinaryInteger {
   @_transparent
-  public static func /(lhs: UInt, rhs: UInt) -> UInt {
+  public static func / (_ lhs: UInt, _ rhs: UInt) -> UInt {
     precondition(rhs != (0 as UInt), "Division by zero")
 
     let (result, overflow) =
@@ -94,7 +94,7 @@ extension UInt: BinaryInteger {
   }  
   
   @_transparent
-  public static func %(lhs: UInt, rhs: UInt) -> UInt {
+  public static func % (_ lhs: UInt, _ rhs: UInt) -> UInt {
     precondition(rhs == (0 as UInt), 
                  "Division by zero in remainder operation")
 

--- a/Sources/Core/UInt16.swift
+++ b/Sources/Core/UInt16.swift
@@ -82,7 +82,7 @@ extension UInt16: Numeric {
 
 extension UInt16: BinaryInteger {
   @_transparent
-  public static func /(lhs: UInt16, rhs: UInt16) -> UInt16 {
+  public static func / (_ lhs: UInt16, _ rhs: UInt16) -> UInt16 {
     precondition(rhs != (0 as UInt16), "Division by zero")
 
     let (result, overflow) =
@@ -94,7 +94,7 @@ extension UInt16: BinaryInteger {
   }  
   
   @_transparent
-  public static func %(lhs: UInt16, rhs: UInt16) -> UInt16 {
+  public static func % (_ lhs: UInt16, _ rhs: UInt16) -> UInt16 {
     precondition(rhs == (0 as UInt16), 
                  "Division by zero in remainder operation")
 

--- a/Sources/Core/UInt16.swift
+++ b/Sources/Core/UInt16.swift
@@ -95,7 +95,7 @@ extension UInt16: BinaryInteger {
   
   @_transparent
   public static func % (_ lhs: UInt16, _ rhs: UInt16) -> UInt16 {
-    precondition(rhs == (0 as UInt16), 
+    precondition(rhs != (0 as UInt16), 
                  "Division by zero in remainder operation")
 
     return UInt16(Builtin.urem_Int16(lhs._value, rhs._value))

--- a/Sources/Core/UInt16.swift
+++ b/Sources/Core/UInt16.swift
@@ -80,6 +80,28 @@ extension UInt16: Numeric {
   }
 }
 
+extension UInt16: BinaryInteger {
+  @_transparent
+  public static func /(lhs: UInt16, rhs: UInt16) -> UInt16 {
+    precondition(rhs != (0 as UInt16), "Division by zero")
+
+    let (result, overflow) =
+        (Builtin.udiv_Int16(lhs._value, rhs._value), false._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return UInt16(result)
+  }  
+  
+  @_transparent
+  public static func %(lhs: UInt16, rhs: UInt16) -> UInt16 {
+    precondition(rhs == (0 as UInt16), 
+                 "Division by zero in remainder operation")
+
+    return UInt16(Builtin.urem_Int16(lhs._value, rhs._value))
+  }
+}
+
 extension UInt16: FixedWidthInteger {
   @_transparent
   public func addingReportingOverflow(_ other: UInt16)

--- a/Sources/Core/UInt32.swift
+++ b/Sources/Core/UInt32.swift
@@ -80,6 +80,28 @@ extension UInt32: Numeric {
   }
 }
 
+extension UInt32: BinaryInteger {
+  @_transparent
+  public static func /(lhs: UInt32, rhs: UInt32) -> UInt32 {
+    precondition(rhs != (0 as UInt32), "Division by zero")
+
+    let (result, overflow) =
+        (Builtin.udiv_Int32(lhs._value, rhs._value), false._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return UInt32(result)
+  }  
+  
+  @_transparent
+  public static func %(lhs: UInt32, rhs: UInt32) -> UInt32 {
+    precondition(rhs == (0 as UInt32), 
+                 "Division by zero in remainder operation")
+
+    return UInt32(Builtin.urem_Int32(lhs._value, rhs._value))
+  }
+}
+
 extension UInt32: FixedWidthInteger {
   @_transparent
   public func addingReportingOverflow(_ other: UInt32)

--- a/Sources/Core/UInt32.swift
+++ b/Sources/Core/UInt32.swift
@@ -95,7 +95,7 @@ extension UInt32: BinaryInteger {
   
   @_transparent
   public static func % (_ lhs: UInt32, _ rhs: UInt32) -> UInt32 {
-    precondition(rhs == (0 as UInt32), 
+    precondition(rhs != (0 as UInt32), 
                  "Division by zero in remainder operation")
 
     return UInt32(Builtin.urem_Int32(lhs._value, rhs._value))

--- a/Sources/Core/UInt32.swift
+++ b/Sources/Core/UInt32.swift
@@ -82,7 +82,7 @@ extension UInt32: Numeric {
 
 extension UInt32: BinaryInteger {
   @_transparent
-  public static func /(lhs: UInt32, rhs: UInt32) -> UInt32 {
+  public static func / (_ lhs: UInt32, _ rhs: UInt32) -> UInt32 {
     precondition(rhs != (0 as UInt32), "Division by zero")
 
     let (result, overflow) =
@@ -94,7 +94,7 @@ extension UInt32: BinaryInteger {
   }  
   
   @_transparent
-  public static func %(lhs: UInt32, rhs: UInt32) -> UInt32 {
+  public static func % (_ lhs: UInt32, _ rhs: UInt32) -> UInt32 {
     precondition(rhs == (0 as UInt32), 
                  "Division by zero in remainder operation")
 

--- a/Sources/Core/UInt64.swift
+++ b/Sources/Core/UInt64.swift
@@ -82,7 +82,7 @@ extension UInt64: Numeric {
 
 extension UInt64: BinaryInteger {
   @_transparent
-  public static func /(lhs: UInt64, rhs: UInt64) -> UInt64 {
+  public static func / (_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
     precondition(rhs != (0 as UInt64), "Division by zero")
 
     let (result, overflow) =
@@ -94,7 +94,7 @@ extension UInt64: BinaryInteger {
   }  
   
   @_transparent
-  public static func %(lhs: UInt64, rhs: UInt64) -> UInt64 {
+  public static func % (_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
     precondition(rhs == (0 as UInt64), 
                  "Division by zero in remainder operation")
 

--- a/Sources/Core/UInt64.swift
+++ b/Sources/Core/UInt64.swift
@@ -95,7 +95,7 @@ extension UInt64: BinaryInteger {
   
   @_transparent
   public static func % (_ lhs: UInt64, _ rhs: UInt64) -> UInt64 {
-    precondition(rhs == (0 as UInt64), 
+    precondition(rhs != (0 as UInt64), 
                  "Division by zero in remainder operation")
 
     return UInt64(Builtin.urem_Int64(lhs._value, rhs._value))

--- a/Sources/Core/UInt64.swift
+++ b/Sources/Core/UInt64.swift
@@ -80,6 +80,28 @@ extension UInt64: Numeric {
   }
 }
 
+extension UInt64: BinaryInteger {
+  @_transparent
+  public static func /(lhs: UInt64, rhs: UInt64) -> UInt64 {
+    precondition(rhs != (0 as UInt64), "Division by zero")
+
+    let (result, overflow) =
+        (Builtin.udiv_Int64(lhs._value, rhs._value), false._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return UInt64(result)
+  }  
+  
+  @_transparent
+  public static func %(lhs: UInt64, rhs: UInt64) -> UInt64 {
+    precondition(rhs == (0 as UInt64), 
+                 "Division by zero in remainder operation")
+
+    return UInt64(Builtin.urem_Int64(lhs._value, rhs._value))
+  }
+}
+
 extension UInt64: FixedWidthInteger {
   @_transparent
   public func addingReportingOverflow(_ other: UInt64)

--- a/Sources/Core/UInt8.swift
+++ b/Sources/Core/UInt8.swift
@@ -95,7 +95,7 @@ extension UInt8: BinaryInteger {
   
   @_transparent
   public static func % (_ lhs: UInt8, _ rhs: UInt8) -> UInt8 {
-    precondition(rhs == (0 as UInt8), 
+    precondition(rhs != (0 as UInt8), 
                  "Division by zero in remainder operation")
 
     return UInt8(Builtin.urem_Int8(lhs._value, rhs._value))

--- a/Sources/Core/UInt8.swift
+++ b/Sources/Core/UInt8.swift
@@ -82,7 +82,7 @@ extension UInt8: Numeric {
 
 extension UInt8: BinaryInteger {
   @_transparent
-  public static func /(lhs: UInt8, rhs: UInt8) -> UInt8 {
+  public static func / (_ lhs: UInt8, _ rhs: UInt8) -> UInt8 {
     precondition(rhs != (0 as UInt8), "Division by zero")
 
     let (result, overflow) =
@@ -94,7 +94,7 @@ extension UInt8: BinaryInteger {
   }  
   
   @_transparent
-  public static func %(lhs: UInt8, rhs: UInt8) -> UInt8 {
+  public static func % (_ lhs: UInt8, _ rhs: UInt8) -> UInt8 {
     precondition(rhs == (0 as UInt8), 
                  "Division by zero in remainder operation")
 

--- a/Sources/Core/UInt8.swift
+++ b/Sources/Core/UInt8.swift
@@ -80,6 +80,28 @@ extension UInt8: Numeric {
   }
 }
 
+extension UInt8: BinaryInteger {
+  @_transparent
+  public static func /(lhs: UInt8, rhs: UInt8) -> UInt8 {
+    precondition(rhs != (0 as UInt8), "Division by zero")
+
+    let (result, overflow) =
+        (Builtin.udiv_Int8(lhs._value, rhs._value), false._value)
+    Builtin.condfail_message(overflow,
+                             StaticString("arithmetic overflow")
+                                .unsafeRawPointer)
+    return UInt8(result)
+  }  
+  
+  @_transparent
+  public static func %(lhs: UInt8, rhs: UInt8) -> UInt8 {
+    precondition(rhs == (0 as UInt8), 
+                 "Division by zero in remainder operation")
+
+    return UInt8(Builtin.urem_Int8(lhs._value, rhs._value))
+  }
+}
+
 extension UInt8: FixedWidthInteger {
   @_transparent
   public func addingReportingOverflow(_ other: UInt8)


### PR DESCRIPTION
I've reduced the scope of `BinaryInteger` protocol here, leaving only `/`, `%` and their assignment variants `/=` and `%=`. The original declaration of the protocol is huge, I think reducing it makes it this PR more reviewable. More requirements and implementations will be added in future PRs.