### PR TITLE
CI: use latest Swift 5.6.1 release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,8 +19,8 @@ jobs:
           - branch: swift-5.5-release
             tag: 5.5-RELEASE
 
-          - branch: swift-5.6-branch
-            tag: 5.6-DEVELOPMENT-SNAPSHOT-2022-02-11-a
+          - branch: swift-5.6.1-release
+            tag: 5.6.1-RELEASE
 
           - branch: development
             tag: DEVELOPMENT-SNAPSHOT-2021-09-18-a


### PR DESCRIPTION
Now that Swift 5.6 has been released, there doesn't seem to be a point in testing with 5.6 snapshots.