### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
             tag: 5.6.1-RELEASE
 
           - branch: development
-            tag: DEVELOPMENT-SNAPSHOT-2021-09-18-a
+            tag: DEVELOPMENT-SNAPSHOT-2022-09-06-a
 
     steps:
       - name: Install Swift ${{ matrix.tag }}


### PR DESCRIPTION
Update to the 9/6/22 snapshot.  This should hopefully have a new enough driver to enable us to migrate to swift-driver.