### PR TITLE
Bugfix: make 'func /=' divide, not add.

### DIFF
--- a/Sources/Core/BinaryInteger.swift
+++ b/Sources/Core/BinaryInteger.swift
@@ -20,7 +20,7 @@ public protocol BinaryInteger: Numeric {
 extension BinaryInteger {
   @_transparent
   public static func /= (_ lhs: inout Self, _ rhs: Self) {
-    lhs = lhs + rhs
+    lhs = lhs / rhs
   }
 }
 


### PR DESCRIPTION
This is a trivial bug fix that closes #86.